### PR TITLE
Update links to docs.hubverse.io

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -38,11 +38,11 @@ Examples of unacceptable behavior include:
 
 ## Enforcement Responsibilities
 
-Community leaders are responsible for clarifying our standards of acceptable behavior. Enforcement is the responsibility of the [Code of Conduct Committee](https://hubverse.io/en/latest/coc/committee.html), who will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful. 
+Community leaders are responsible for clarifying our standards of acceptable behavior. Enforcement is the responsibility of the [Code of Conduct Committee](https://docs.hubverse.io/en/latest/coc/committee.html), who will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful. 
 
-Instances of abusive, harassing, or otherwise unacceptable behavior [may be reported to any member of the Code of Conduct Committee](https://hubverse.io/en/latest/coc/committee.html). All complaints will be reviewed and investigated promptly and fairly. 
+Instances of abusive, harassing, or otherwise unacceptable behavior [may be reported to any member of the Code of Conduct Committee](https://docs.hubverse.io/en/latest/coc/committee.html). All complaints will be reviewed and investigated promptly and fairly. 
 
-The Code of Conduct Committee will use the [Enforcement Manual](https://hubverse.io/en/latest/coc/enforcement-manual.html) in determining the consequences for any action they deem in violation of this Code of Conduct. All community leaders and Code of Conduct Committee members are obligated to respect the privacy and security of the reporter of any incident.
+The Code of Conduct Committee will use the [Enforcement Manual](https://docs.hubverse.io/en/latest/coc/enforcement-manual.html) in determining the consequences for any action they deem in violation of this Code of Conduct. All community leaders and Code of Conduct Committee members are obligated to respect the privacy and security of the reporter of any incident.
 
 
 ## Scope

--- a/profile/README.md
+++ b/profile/README.md
@@ -7,4 +7,4 @@
 
 The hubverse is a collection of open-source software and data tools that enables collaborative modeling exercises. It is developed by the Consortium of Infectious Disease Modeling Hubs, a collaboration of research teams and public health professionals that have built and maintained predictive modeling hubs for infectious disease applications. Working together, we have developed the hubverse for groups that are running collaborative modeling hub efforts. This website documents the requirements for using the hubverse.
 
-For more information, [visit our docs](https://hubverse.io/en/latest/)
+For more information, [visit our docs](https://docs.hubverse.io/en/latest/)


### PR DESCRIPTION
This PR updates `hubverse.io` URLs to point to `docs.hubverse.io`.

📝 Multiple commits — feel free to **Squash and Merge** to keep history clean.